### PR TITLE
Adds enhancement for dangerous lookup from PR merged yesterday

### DIFF
--- a/ImageGoNord/GoNord.py
+++ b/ImageGoNord/GoNord.py
@@ -173,7 +173,8 @@ class GoNord(object):
                 self.PALETTE_DATA[hex_color] = pl.export_tripletes_from_color(
                     hex_color)
 
-        if len(self.PALETTE_DATA['']) == 0:
+        # Delete empty lines, if they exist.
+        if self.PALETTE_DATA.get('') and len(self.PALETTE_DATA['']) == 0:
             del self.PALETTE_DATA['']
 
         return self.PALETTE_DATA


### PR DESCRIPTION
The pull request merged yesterday: https://github.com/Schrodinger-Hat/ImageGoNord-pip/pull/6 has a potential problem. If the file _does not_ have an empty line at the end, the dict lookup throws a key error.

I've notice it while using another library that has `ImageGoNord-pip` listed as a dependency. In their case, they don't have an empty line at the end of the file https://github.com/paulopacitti/gruvbox-factory/issues/3 

source: https://github.com/paulopacitti/gruvbox-factory/blob/master/factory/gruvbox.txt

I've changed this lookup to check if the key is present in the dictionary first before trying to access it.

Thanks