### PR TITLE
feat(25): make models optionals

### DIFF
--- a/ImageGoNord/GoNord.py
+++ b/ImageGoNord/GoNord.py
@@ -19,7 +19,8 @@ try:
     import skimage.color as convertor
     import torchvision.transforms as transforms
 except ImportError:
-    print("Please install the dependencies required for the AI feature")
+    # AI feature disabled
+    pass
 
 
 try:
@@ -38,7 +39,8 @@ from ImageGoNord.utility.ConvertUtility import ConvertUtility
 try:
     from ImageGoNord.utility.model import FeatureEncoder,RecoloringDecoder
 except ImportError:
-    print("Please install the dependencies required for the AI feature")
+    # AI feature disabled
+    pass
 
 
 class NordPaletteFile:
@@ -543,8 +545,11 @@ class GoNord(object):
         pixels = self.load_pixel_image(image)
         is_rgba = (image.mode == 'RGBA')
 
-        if use_model and torch != None:
-            image = self.convert_image_by_model(image, use_model_cpu)
+        if use_model:
+            if torch != None:
+                image = self.convert_image_by_model(image, use_model_cpu)
+            else:
+                print('Please install the dependencies required for the AI feature: pip install image-go-nord[AI]')
         else:
             if not parallel_threading:
                 self.converted_loop(is_rgba, pixels, original_pixels, image.size[0], image.size[1])

--- a/ImageGoNord/__init__.py
+++ b/ImageGoNord/__init__.py
@@ -1,4 +1,4 @@
 # gonord version
-__version__ = "1.0.2"
+__version__ = "1.1.0"
 
 from ImageGoNord.GoNord import *

--- a/index.py
+++ b/index.py
@@ -22,12 +22,10 @@ go_nord.disable_avg_algorithm()
 # go_nord.add_file_to_palette(NordPaletteFile.AURORA)
 # go_nord.add_file_to_palette(NordPaletteFile.FROST)
 
-# image = go_nord.open_image("images/valley.jpg")
-# go_nord.convert_image(image, save_path="images/test-valley-ai.jpg", use_model=True)
-
-output_path = go_nord.convert_video('videos/SampleVideo_720x480.mp4', 'custom_palette', save_path='videos/SampleVideo_converted.mp4')
-print(output_path)
+image = go_nord.open_image("images/valley.jpg")
+go_nord.convert_image(image, save_path="images/test-valley-ai.jpg", use_model=True)
 exit()
+# output_path = go_nord.convert_video('videos/SampleVideo_720x480.mp4', 'custom_palette', save_path='videos/SampleVideo_converted.mp4')
 
 image = go_nord.open_image("images/test.jpg")
 resized_img = go_nord.resize_image(image)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (ROOT / "README.md").read_text()
 
 setup(
     name="image-go-nord",
-    version="1.0.2",
+    version="1.1.0",
     description="A tool to convert any RGB image or video to any theme or color palette input by the user",
     long_description=README,
     long_description_content_type="text/markdown",
@@ -17,7 +17,7 @@ setup(
     author_email="schrodinger.hat.show@gmail.com",
     license="AGPL-3.0",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',      # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
         "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
@@ -30,8 +30,11 @@ setup(
         "Bug Reports": "https://github.com/Schrodinger-Hat/ImageGoNord-pip/issues",
     },
     packages=find_packages(),
-    package_data={'': ['*.txt', 'palettes/*.txt', 'models/*.pt', '*.pt', '*.state_dict.*']},
+    package_data={'': ['*.txt', 'palettes/*.txt']},
     include_package_data=True,
-    install_requires=["Pillow", "ffmpeg-python", "numpy", "torch", "scikit-image", "torchvision"],
+    install_requires=["Pillow", "ffmpeg-python", "numpy", "requests"],
+    extras_require = {
+        'AI':  ["torch", "scikit-image", "torchvision"]
+    },
     python_requires=">=3.5"
 )


### PR DESCRIPTION
Closes #25 

This PR will make the .pt files optionals and loadable from this repository.
On the latest release the package was having a 30MB size standalone and more than 700 MB if we consider the dependencies.

We should let the user decide which algorithm use for converting an image.
After this PR, we're going to release a minor.